### PR TITLE
Fix: Attribute error on element text

### DIFF
--- a/fisherman.py
+++ b/fisherman.py
@@ -356,11 +356,12 @@ def extra_data(brw: Firefox, user: AnyStr):
     if not ARGS.quiet:
         print(f'[{color_text("green", "+")}] picture saved')
 
-    element = collection_by_xpath(ec.visibility_of_element_located, xpaths.bio).text
-    if element:
-        bio = element
-    else:
+    try:
+        element = collection_by_xpath(ec.visibility_of_element_located, xpaths.bio).text
+    except AttributeError:
         bio = None
+    else:
+        bio = element
 
     if collection_by_xpath(ec.visibility_of_element_located, xpaths.followers) is not None:
         followers = str(collection_by_xpath(ec.visibility_of_element_located, xpaths.followers).text).split()[0]


### PR DESCRIPTION
When running with `-s`option i got:

```
Traceback (most recent call last):
File "fisherman.py", line 697, in <module>
raise error
File "fisherman.py", line 693, in <module>
scrape(browser, ARGS.username)
File "fisherman.py", line 469, in scrape
extra_data(brw, usrs)
File "fisherman.py", line 359, in extra_data
element = collection_by_xpath(ec.visibility_of_element_located, xpaths.bio).text
AttributeError: 'NoneType' object has no attribute 'text'
```
Just add try and catch.